### PR TITLE
Platform and triplet

### DIFF
--- a/Engine/scripts/utils.cmake
+++ b/Engine/scripts/utils.cmake
@@ -220,11 +220,19 @@ function(getToolsetTriplet out_triplet)
 		set(_toolset "v${MSVC_TOOLSET_VERSION}")
 	elseif(DEFINED CMAKE_VS_PLATFORM_TOOLSET)
 		set(_toolset "${CMAKE_VS_PLATFORM_TOOLSET}")
+	elseif(UNIX)
+		set(_toolset "")
 	else()
 		message(FATAL_ERROR "Visual studio toolset couldn't be deduced from cmake")
 	endif()
 
-	set(${out_triplet} "${_vcpkgTarget}-${_toolset}${_config}" PARENT_SCOPE)
+	set(_out_triplet "${_vcpkgTarget}")
+	if(NOT "${_toolset}" STREQUAL "")
+		set(_out_triplet "${_out_triplet}-${_toolset}")
+	endif()
+	set(_out_triplet "${_out_triplet}${_config}")
+
+	set(${out_triplet} "${_out_triplet}" PARENT_SCOPE)
 endfunction(getToolsetTriplet)
 
 

--- a/Engine/scripts/utils.cmake
+++ b/Engine/scripts/utils.cmake
@@ -35,8 +35,14 @@ function(getPlatformArch platform_architecture)
 		else() # 32 bit
 			set(${platform_architecture} "x32" PARENT_SCOPE)
 		endif()
-	else()
+	elseif(WIN32)
 		if("${CMAKE_GENERATOR}" MATCHES "(Win64|IA64)") # 64 bit
+			set(${platform_architecture} "x64" PARENT_SCOPE)
+		else() # 32 bit
+			set(${platform_architecture} "x32" PARENT_SCOPE)
+		endif()
+	else()
+		if(CMAKE_SIZEOF_VOID_P GREATER 4) # 64 bit
 			set(${platform_architecture} "x64" PARENT_SCOPE)
 		else() # 32 bit
 			set(${platform_architecture} "x32" PARENT_SCOPE)


### PR DESCRIPTION
- add detection for platform arch on linux systems
- allow vcpkg triplets without a toolchain part like `x64-linux`