### PR TITLE
replace NONE language targets with custom_target

### DIFF
--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -43,10 +43,9 @@ file(GLOB_RECURSE engineFiles
 	${CMAKE_CURRENT_SOURCE_DIR}/config/* )
 
 message(STATUS "Adding target: General")
-add_custom_target(General ${generalFiles} ${engineFiles})
-#set_target_properties(General PROPERTIES LINKER_LANGUAGE NONE) # we don't build this library
-#assign_source_group(${engineFiles})
-#assignIdeFolder(General Engine/General)
+add_custom_target(General ALL SOURCES ${generalFiles} ${engineFiles})
+assign_source_group(${engineFiles})
+assignIdeFolder(General Engine/General)
 
 
 # all other targets are under source and resources

--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -43,10 +43,10 @@ file(GLOB_RECURSE engineFiles
 	${CMAKE_CURRENT_SOURCE_DIR}/config/* )
 
 message(STATUS "Adding target: General")
-add_library(General ${generalFiles} ${engineFiles})
-set_target_properties(General PROPERTIES LINKER_LANGUAGE NONE) # we don't build this library
-assign_source_group(${engineFiles})
-assignIdeFolder(General Engine/General)
+add_custom_target(General ${generalFiles} ${engineFiles})
+#set_target_properties(General PROPERTIES LINKER_LANGUAGE NONE) # we don't build this library
+#assign_source_group(${engineFiles})
+#assignIdeFolder(General Engine/General)
 
 
 # all other targets are under source and resources

--- a/Engine/scripts/utils.cmake
+++ b/Engine/scripts/utils.cmake
@@ -115,10 +115,9 @@ function(createProjectGeneral)
 	file(GLOB_RECURSE projectFiles ${PROJECT_DIRECTORY}/resources/*)
 
 	message(STATUS "Adding target: GeneralProject")
-	add_custom_target(GeneralProject ${projectFiles})
-	#set_target_properties(GeneralProject PROPERTIES LINKER_LANGUAGE NONE) # we don't build this library
-	#assign_source_group(${projectFiles})
-	#assignIdeFolder(GeneralProject Project/General)
+	add_custom_target(GeneralProject ALL SOURCES ${projectFiles})
+	assign_source_group(${projectFiles})
+	assignIdeFolder(GeneralProject Project/General)
 
 endfunction(createProjectGeneral)
 

--- a/Engine/scripts/utils.cmake
+++ b/Engine/scripts/utils.cmake
@@ -115,10 +115,10 @@ function(createProjectGeneral)
 	file(GLOB_RECURSE projectFiles ${PROJECT_DIRECTORY}/resources/*)
 
 	message(STATUS "Adding target: GeneralProject")
-	add_library(GeneralProject ${projectFiles})
-	set_target_properties(GeneralProject PROPERTIES LINKER_LANGUAGE NONE) # we don't build this library
-	assign_source_group(${projectFiles})
-	assignIdeFolder(GeneralProject Project/General)
+	add_custom_target(GeneralProject ${projectFiles})
+	#set_target_properties(GeneralProject PROPERTIES LINKER_LANGUAGE NONE) # we don't build this library
+	#assign_source_group(${projectFiles})
+	#assignIdeFolder(GeneralProject Project/General)
 
 endfunction(createProjectGeneral)
 


### PR DESCRIPTION
I got an error message for the library targets with the `NONE` linker language. I think those targets are just here to be shown in the IDE. For this we could use a custom target.

I wasn't able to test this change, therefore the `[WIP]` flag