### PR TITLE
Json and platform

### DIFF
--- a/Engine/scripts/utils.cmake
+++ b/Engine/scripts/utils.cmake
@@ -184,6 +184,8 @@ function(target_definitions)
 	# os
 	if (MSVC)
 		add_definitions(-DPLATFORM_Win)
+	else()
+		add_definitions(-DPLATFORM_Linux)
 	endif(MSVC)
 	
 	set(_p )

--- a/Engine/source/EtCore/FileSystem/Json/JsonDom.cpp
+++ b/Engine/source/EtCore/FileSystem/Json/JsonDom.cpp
@@ -1,5 +1,5 @@
 #include "stdafx.h"
-#include "JSONdom.h"
+#include "JsonDom.h"
 
 
 namespace et {

--- a/Engine/source/EtCore/FileSystem/Json/JsonParser.cpp
+++ b/Engine/source/EtCore/FileSystem/Json/JsonParser.cpp
@@ -1,5 +1,5 @@
 #include "stdafx.h"
-#include "JSONparser.h"
+#include "JsonParser.h"
 
 #include <functional>
 #include <cctype>

--- a/Engine/source/EtCore/FileSystem/Json/JsonParser.h
+++ b/Engine/source/EtCore/FileSystem/Json/JsonParser.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "JSONdom.h"
+#include "JsonDom.h"
 
 
 namespace et {


### PR DESCRIPTION
- define PLATFORM_Linux when we are not on MSVC
- fix the Json includes (linux is case sensitive most of the time)