### PR TITLE
Custom vcpkg

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -27,7 +27,7 @@
 	url = https://github.com/nothings/stb
 [submodule "third_party/vcpkg/vcpkg"]
 	path = Engine/third_party/vcpkg/vcpkg
-	url = https://github.com/Microsoft/vcpkg
+	url = https://github.com/Illation/vcpkg
 [submodule "Engine/third_party/gtk/GTK-for-Windows-Runtime-Environment-Installer"]
 	path = Engine/third_party/gtk/GTK-for-Windows-Runtime-Environment-Installer
 	url = https://github.com/tschoonj/GTK-for-Windows-Runtime-Environment-Installer

--- a/Engine/scripts/utils.cmake
+++ b/Engine/scripts/utils.cmake
@@ -392,7 +392,7 @@ function(editorLinks TARGET)
 		debug ${_dbg}pixman-1d.lib			optimized ${_rel}pixman-1.lib	
 
 		debug ${_dbg}atk-1.0.lib			optimized ${_rel}atk-1.0.lib	 
-		debug ${_dbg}atkmm.lib				optimized ${_rel}atkmm.lib	 
+		debug ${_dbg}atkmm-1.6.lib			optimized ${_rel}atkmm-1.6.lib	 
 		debug ${_dbg}cairomm-1.0.lib		optimized ${_rel}cairomm-1.0.lib	 
 		debug ${_dbg}epoxy.lib				optimized ${_rel}epoxy.lib	 
 		debug ${_dbg}expat.lib				optimized ${_rel}expat.lib	 
@@ -400,7 +400,7 @@ function(editorLinks TARGET)
 		debug ${_dbg}gailutil-3.0.lib		optimized ${_rel}gailutil-3.0.lib	 
 		debug ${_dbg}gdk_pixbuf-2.0.lib		optimized ${_rel}gdk_pixbuf-2.0.lib	 
 		debug ${_dbg}gdk-3.0.lib			optimized ${_rel}gdk-3.0.lib	 
-		debug ${_dbg}gdkmm.lib				optimized ${_rel}gdkmm.lib	 
+		debug ${_dbg}gdkmm-3.0.lib			optimized ${_rel}gdkmm-3.0.lib	 
 		debug ${_dbg}gio-2.0.lib			optimized ${_rel}gio-2.0.lib	 
 		debug ${_dbg}giomm.lib				optimized ${_rel}giomm.lib	 
 		debug ${_dbg}glib-2.0.lib			optimized ${_rel}glib-2.0.lib	 
@@ -409,7 +409,7 @@ function(editorLinks TARGET)
 		debug ${_dbg}gobject-2.0.lib		optimized ${_rel}gobject-2.0.lib	 
 		debug ${_dbg}gthread-2.0.lib		optimized ${_rel}gthread-2.0.lib	 
 		debug ${_dbg}gtk-3.0.lib			optimized ${_rel}gtk-3.0.lib	 
-		debug ${_dbg}gtkmm.lib				optimized ${_rel}gtkmm.lib	 
+		debug ${_dbg}gtkmm-3.0.lib			optimized ${_rel}gtkmm-3.0.lib	 
 		debug ${_dbg}harfbuzz.lib			optimized ${_rel}harfbuzz.lib	 
 		debug ${_dbg}libcharset.lib			optimized ${_rel}libcharset.lib	 
 		debug ${_dbg}libffi.lib				optimized ${_rel}libffi.lib	 

--- a/Engine/third_party/CMakeLists.txt
+++ b/Engine/third_party/CMakeLists.txt
@@ -12,9 +12,15 @@ find_package(Git QUIET)
 if(GIT_FOUND AND EXISTS "${ENGINE_REPO_DIR}/.git")
 # Update submodules as needed
     message(STATUS "Submodule update")
-    execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
-                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                    RESULT_VARIABLE GIT_SUBMOD_RESULT)
+	if(ETE_UPDATE_SUBMODULES)
+		execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive --remote ${ETE_UPDATE_SUBMODULE_PATH}
+						WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+						RESULT_VARIABLE GIT_SUBMOD_RESULT)
+	else()
+		execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
+						WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+						RESULT_VARIABLE GIT_SUBMOD_RESULT)
+	endif()
     if(NOT GIT_SUBMOD_RESULT EQUAL "0")
         message(FATAL_ERROR "git submodule update --init failed with ${GIT_SUBMOD_RESULT}, please checkout submodules")
     endif()

--- a/Projects/Demo/CMakeLists.txt
+++ b/Projects/Demo/CMakeLists.txt
@@ -19,6 +19,8 @@ message(STATUS "Engine path: ${ENGINE_DIRECTORY_ABS}")
 message(STATUS "Project path: ${PROJECT_DIRECTORY}")
 message(STATUS "//////////////////////////////////////////////////////////////////////////////////////////")
 
+option(ETE_UPDATE_SUBMODULES "Update third party submodules to their latest state" OFF)
+set(ETE_UPDATE_SUBMODULE_PATH "" CACHE STRING "Which submodule to update specifically")
 # Continuous integration doesn't need to build all configurations for libraries
 option(ETE_SINGLE_CONFIG "Build libraries for a single configuration" OFF)
 set(ETE_BUILD_LIB_CONFIG "Debug" CACHE STRING "Which configuration to build the library for in case of a single configuration build")


### PR DESCRIPTION
This change replaces the microsoft/vcpkg repository with a fork that has changes to make gtkmm build correctly.

In the microsoft version, gtkmm doesn't emit symbols for the tree view in release mode, preventing Develop  and Shipping builds of the editor. This is now fixed.