### PR TITLE
Normalized midpoint calculation

### DIFF
--- a/Engine/source/EtRendering/GlobalRenderingSystems/PrimitiveRenderer.cpp
+++ b/Engine/source/EtRendering/GlobalRenderingSystems/PrimitiveRenderer.cpp
@@ -230,10 +230,10 @@ void primitives::IcoSphere<level>::SubAndPush(std::vector<vec3> &vertices, const
 {
 	if (lev < level)
 	{
-		//find midpoints
-		vec3 A = math::normalize((b + c) * 0.5f);
-		vec3 B = math::normalize((c + a) * 0.5f);
-		vec3 C = math::normalize((a + b) * 0.5f);
+		//find normalized midpoints
+		vec3 A = math::normalize(b + c);
+		vec3 B = math::normalize(c + a);
+		vec3 C = math::normalize(a + b);
 		//Make 4 new triangles
 		int32 nLevel = lev + 1;
 		SubAndPush(vertices, nLevel, B, A, c);

--- a/Engine/source/EtRendering/GlobalRenderingSystems/PrimitiveRenderer.cpp
+++ b/Engine/source/EtRendering/GlobalRenderingSystems/PrimitiveRenderer.cpp
@@ -231,9 +231,9 @@ void primitives::IcoSphere<level>::SubAndPush(std::vector<vec3> &vertices, const
 	if (lev < level)
 	{
 		//find midpoints
-		vec3 A = math::normalize(b + ((c - b)*0.5f));
-		vec3 B = math::normalize(c + ((a - c)*0.5f));
-		vec3 C = math::normalize(a + ((b - a)*0.5f));
+		vec3 A = math::normalize((b + c) * 0.5f);
+		vec3 B = math::normalize((c + a) * 0.5f);
+		vec3 C = math::normalize((a + b) * 0.5f);
 		//Make 4 new triangles
 		int32 nLevel = lev + 1;
 		SubAndPush(vertices, nLevel, B, A, c);

--- a/Engine/source/EtRendering/PlanetTech/Triangulator.cpp
+++ b/Engine/source/EtRendering/PlanetTech/Triangulator.cpp
@@ -69,12 +69,12 @@ void Triangulator::Precalculate()
 	float normMaxHeight = m_Planet->GetMaxHeight() / m_Planet->GetRadius();
 	for (int32 i = 1; i <= m_MaxLevel; i++)
 	{
-		vec3 A = b + ((c - b)*0.5f);
-		vec3 B = c + ((a - c)*0.5f);
-		c = a + ((b - a)*0.5f);
+		vec3 A = (b + c) * 0.5f;
+		vec3 B = (c + a) * 0.5f;
+		vec3 C = (a + b) * 0.5f;
 		a = A * m_Planet->GetRadius() / math::length(A);
 		b = B * m_Planet->GetRadius() / math::length(B);
-		c = c * m_Planet->GetRadius() / math::length(c);
+		c = C * m_Planet->GetRadius() / math::length(C);
 		m_HeightMultLUT.push_back(1 / math::dot( math::normalize(a), math::normalize(center)) + normMaxHeight);
 	}
 }
@@ -150,9 +150,9 @@ void Triangulator::RecursiveTriangle(vec3 a, vec3 b, vec3 c, int16 level, bool f
 	else if (next == SPLIT || next == SPLITCULL)
 	{
 		//find midpoints
-		vec3 A = b + ((c - b)*0.5f);
-		vec3 B = c + ((a - c)*0.5f);
-		vec3 C = a + ((b - a)*0.5f);
+		vec3 A = (b + c) * 0.5f;
+		vec3 B = (c + a) * 0.5f;
+		vec3 C = (a + b) * 0.5f;
 		//make the distance from center larger according to planet radius
 		A = A * m_Planet->GetRadius() / math::length(A);
 		B = B * m_Planet->GetRadius() / math::length(B);

--- a/Engine/source/EtRendering/PlanetTech/Triangulator.cpp
+++ b/Engine/source/EtRendering/PlanetTech/Triangulator.cpp
@@ -69,12 +69,12 @@ void Triangulator::Precalculate()
 	float normMaxHeight = m_Planet->GetMaxHeight() / m_Planet->GetRadius();
 	for (int32 i = 1; i <= m_MaxLevel; i++)
 	{
-		vec3 A = (b + c) * 0.5f;
-		vec3 B = (c + a) * 0.5f;
-		vec3 C = (a + b) * 0.5f;
-		a = math::normalize(A) * m_Planet->GetRadius();
-		b = math::normalize(B) * m_Planet->GetRadius();
-		c = math::normalize(C) * m_Planet->GetRadius();
+		vec3 A = math::normalize(b + c);
+		vec3 B = math::normalize(c + a);
+		vec3 C = math::normalize(a + b);
+		a = A * m_Planet->GetRadius();
+		b = B * m_Planet->GetRadius();
+		c = C * m_Planet->GetRadius();
 		m_HeightMultLUT.push_back(1 / math::dot( math::normalize(a), math::normalize(center)) + normMaxHeight);
 	}
 }
@@ -149,14 +149,10 @@ void Triangulator::RecursiveTriangle(vec3 a, vec3 b, vec3 c, int16 level, bool f
 	//check if subdivision is needed based on camera distance
 	else if (next == SPLIT || next == SPLITCULL)
 	{
-		//find midpoints
-		vec3 A = (b + c) * 0.5f;
-		vec3 B = (c + a) * 0.5f;
-		vec3 C = (a + b) * 0.5f;
-		//make the distance from center larger according to planet radius
-		A = math::normalize(A) * m_Planet->GetRadius();
-		B = math::normalize(B) * m_Planet->GetRadius();
-		C = math::normalize(C) * m_Planet->GetRadius();
+		//find normalized midpoints and scale them to planet radius
+		vec3 A = math::normalize(b + c) * m_Planet->GetRadius();
+		vec3 B = math::normalize(c + a) * m_Planet->GetRadius();
+		vec3 C = math::normalize(a + b) * m_Planet->GetRadius();
 		//Make 4 new triangles
 		int16 nLevel = level + 1;
 		RecursiveTriangle(a, B, C, nLevel, next == SPLITCULL);//Winding is inverted

--- a/Engine/source/EtRendering/PlanetTech/Triangulator.cpp
+++ b/Engine/source/EtRendering/PlanetTech/Triangulator.cpp
@@ -64,7 +64,7 @@ void Triangulator::Precalculate()
 	vec3 b = m_Icosahedron[0].b;
 	vec3 c = m_Icosahedron[0].c;
 	vec3 center = (a + b + c) / 3.f;
-	center = center * m_Planet->GetRadius() / math::length(center);//+maxHeight
+	center = math::normalize(center) * m_Planet->GetRadius();//+maxHeight
 	m_HeightMultLUT.push_back(1 / math::dot( math::normalize(a), math::normalize(center)));
 	float normMaxHeight = m_Planet->GetMaxHeight() / m_Planet->GetRadius();
 	for (int32 i = 1; i <= m_MaxLevel; i++)
@@ -72,9 +72,9 @@ void Triangulator::Precalculate()
 		vec3 A = (b + c) * 0.5f;
 		vec3 B = (c + a) * 0.5f;
 		vec3 C = (a + b) * 0.5f;
-		a = A * m_Planet->GetRadius() / math::length(A);
-		b = B * m_Planet->GetRadius() / math::length(B);
-		c = C * m_Planet->GetRadius() / math::length(C);
+		a = math::normalize(A) * m_Planet->GetRadius();
+		b = math::normalize(B) * m_Planet->GetRadius();
+		c = math::normalize(C) * m_Planet->GetRadius();
 		m_HeightMultLUT.push_back(1 / math::dot( math::normalize(a), math::normalize(center)) + normMaxHeight);
 	}
 }
@@ -154,9 +154,9 @@ void Triangulator::RecursiveTriangle(vec3 a, vec3 b, vec3 c, int16 level, bool f
 		vec3 B = (c + a) * 0.5f;
 		vec3 C = (a + b) * 0.5f;
 		//make the distance from center larger according to planet radius
-		A = A * m_Planet->GetRadius() / math::length(A);
-		B = B * m_Planet->GetRadius() / math::length(B);
-		C = C * m_Planet->GetRadius() / math::length(C);
+		A = math::normalize(A) * m_Planet->GetRadius();
+		B = math::normalize(B) * m_Planet->GetRadius();
+		C = math::normalize(C) * m_Planet->GetRadius();
 		//Make 4 new triangles
 		int16 nLevel = level + 1;
 		RecursiveTriangle(a, B, C, nLevel, next == SPLITCULL);//Winding is inverted


### PR DESCRIPTION
This one is a bit less trivial, but worth it I think. I've split it into multiple commits to be easier to follow.

Another optimization I'd like to look into is to precalculate midpoint scale factor.

Midpoint calculation in RecursiveTriangle would be simplified to:
vec3 A = (b + c) * m_MidpointScaleLUT[level];
vec3 B = (c + a) * m_MidpointScaleLUT[level];
vec3 C = (a + b) * m_MidpointScaleLUT[level];